### PR TITLE
fix(compiler): allow referencing viewof and mutable cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "@observablehq/parser": "^1.2.1",
-    "@observablehq/runtime": "^4.4.4"
+    "@observablehq/runtime": "^4.4.4",
+    "acorn-walk": "^7.0.0"
   },
   "devDependencies": {
     "http-server": "^0.11.1",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,8 +1,10 @@
-import { parseCell, parseModule } from "@observablehq/parser";
+import { parseCell, parseModule, walk } from "@observablehq/parser";
 import { Library } from "@observablehq/runtime";
 import { extractPath } from "./utils";
+import { simple } from 'acorn-walk';
 
-const { Generators } = new Library();
+const { Generators, Mutable: constantMutable } = new Library();
+const Mutable = constantMutable();
 
 const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
 const GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
@@ -18,17 +20,52 @@ const createRegularCellDefintion = cell => {
   let name = null;
   if (cell.id && cell.id.name) name = cell.id.name;
   else if (cell.id && cell.id.id && cell.id.id.name) name = cell.id.id.name;
-  const bodyText = cell.input.substring(cell.body.start, cell.body.end);
+  let bodyText = cell.input.substring(cell.body.start, cell.body.end);
+  const cellReferences = (cell.references || []).map(ref => {
+    if (ref.type === "ViewExpression") {
+      return 'viewof ' + ref.id.name;
+    } else if (ref.type === "MutableExpression") {
+      return 'mutable ' + ref.id.name;
+    } else return ref.name;
+  });
+  let $count = 0;
+  let indexShift = 0;
+  const references = (cell.references || []).map(ref => {
+    if (ref.type === "ViewExpression") {
+      const $string = '$' + $count;
+      $count++;
+      // replace "viewof X" in bodyText with "$($count)"
+      simple(cell.body, {
+        ViewExpression(node) {
+          const start = node.start - cell.body.start;
+          const end = node.end - cell.body.start;
+          bodyText = bodyText.slice(0, start + indexShift) + $string + bodyText.slice(end + indexShift);
+          indexShift += $string.length - (end - start);
+        }
+      }, walk);
+      return $string;
+    } else if (ref.type === "MutableExpression") {
+      const $string = '$' + $count;
+      const $stringValue = $string + '.value';
+      $count++;
+      // replace "mutable Y" in bodyText with "$($count).value"
+      simple(cell.body, {
+        MutableExpression(node) {
+          const start = node.start - cell.body.start;
+          const end = node.end - cell.body.start;
+          bodyText = bodyText.slice(0, start + indexShift) + $stringValue + bodyText.slice(end + indexShift);
+          indexShift += $stringValue.length - (end - start);
+        }
+      }, walk);
+      return $string;
+    } else return ref.name;
+  });
   let code;
   if (cell.body.type !== "BlockStatement") {
     if (cell.async)
       code = `return (async function(){ return (${bodyText});})()`;
     else code = `return (function(){ return (${bodyText});})()`;
   } else code = bodyText;
-  const references = (cell.references || []).map(ref => {
-    if (ref.type === "ViewExpression") throw Error("ViewExpression wat");
-    return ref.name;
-  });
 
   let f;
 
@@ -40,7 +77,7 @@ const createRegularCellDefintion = cell => {
   return {
     cellName: name,
     cellFunction: f,
-    cellReferences: references
+    cellReferences
   };
 };
 const createModuleDefintion = (m, resolveModule) => {
@@ -96,7 +133,15 @@ const createModuleDefintion = (m, resolveModule) => {
           main
             .variable(observer(reference))
             .define(reference, cellReferences, cellFunction);
-          main.variable(null).define(cellName, [reference], Generators.input);
+          main.variable(observer(cellName)).define(cellName, [reference], Generators.input);
+        } else if (cell.id && cell.id.type === "MutableExpression") {
+          const initialName = `initial ${cellName}`;
+          const mutableName = `mutable ${cellName}`;
+          main
+            .variable(null)
+            .define(initialName, cellReferences, cellFunction);
+          main.variable(observer(mutableName)).define(mutableName, [initialName], (_) => new Mutable(_));
+          main.variable(observer(cellName)).define(cellName, [mutableName], _ => _.generator);
         } else {
           main
             .variable(observer(cellName))

--- a/test/test.html
+++ b/test/test.html
@@ -40,10 +40,29 @@
       }
     }
 
+    viewof x = html\`<input type="range">\`
+
+    y = x * x
+
+    z = viewof x.valueAsNumber + x
+
+    mutable m = 0
+
+    {
+      const button = html\`<button>increment m, decrement x\`;
+      button.onclick = () => {
+        mutable m++;
+        viewof x.value = viewof x.valueAsNumber - 1;
+        viewof x.dispatchEvent(new CustomEvent('input'));
+      };
+      return button;
+    }
+
+    3*m
+
     d3 = require('d3-array')
 
     html\`<img src="https://images.dog.ceo/breeds/dhole/n02115913_4117.jpg" width="100">\`
-
 
     import {ramp} from "@mbostock/color-ramp"
 
@@ -76,6 +95,6 @@
 `);
 
     const rt = new Runtime();
-    rt.module(define, Inspector.into(document.querySelector("#main")));
+    window.MODULE = rt.module(define, Inspector.into(document.querySelector("#main")));
   </script>
 </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,11 @@ acorn-walk@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
+acorn-walk@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
+  integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
+
 acorn@^6.0.4:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"


### PR DESCRIPTION
Despite the name of the branch, this PR addresses #2: the compiler should now properly treat regular cells that reference `viewof` and `mutable` cells. The tricky part is replacing all the references to "`viewof X`" and "`mutable Y`" with placeholders. For that I used the ObservableHQ's `parser.walk` function with `acorn-walk`, following [some old code](https://observablehq.com/@bryangingechen/from-raw-notebook-source-to-observable-runtime-v1-modules?collection=@bryangingechen/observable#getInputs).

I've added some examples to `test.html`; in the future we probably want to have more systematic tests. I also assigned the module object to the window scope in that HTML file to make future debugging a little more convenient.