### PR TITLE
feat(compiler): viewof & mutable references / imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   ],
   "dependencies": {
     "@observablehq/parser": "^1.2.1",
-    "@observablehq/runtime": "^4.4.4"
+    "@observablehq/runtime": "^4.4.4",
+    "acorn-walk": "^7.0.0"
   },
   "devDependencies": {
     "http-server": "^0.11.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@observablehq/parser": "^1.2.1",
-    "@observablehq/runtime": "^4.4.4",
     "acorn-walk": "^7.0.0"
   },
   "devDependencies": {
@@ -39,6 +38,7 @@
     "rollup": "^1.21.2",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "tape": "^4.11.0"
+    "tape": "^4.11.0",
+    "@observablehq/runtime": "^4.4.4"
   }
 }

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -128,7 +128,7 @@ const createModuleDefintion = (m, resolveModule) => {
           null,
           ["md"],
           md => md`~~~javascript
-    import {${specifiers.map(
+import {${specifiers.map(
       specifier => `${specifier.name} as ${specifier.alias}`
     ).join(', ')}}  ${
             hasInjections
@@ -137,7 +137,7 @@ const createModuleDefintion = (m, resolveModule) => {
                   .join(", ")}} `
               : ``
           }from "${cell.body.source.value}"
-        ~~~`
+~~~`
         );
         const { from } = await createImportCellDefintion(
           cell,

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,8 +1,10 @@
-import { parseCell, parseModule } from "@observablehq/parser";
+import { parseCell, parseModule, walk } from "@observablehq/parser";
 import { Library } from "@observablehq/runtime";
 import { extractPath } from "./utils";
+import { simple } from 'acorn-walk';
 
-const { Generators } = new Library();
+const { Generators, Mutable: constantMutable } = new Library();
+const Mutable = constantMutable();
 
 const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
 const GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
@@ -18,17 +20,52 @@ const createRegularCellDefintion = cell => {
   let name = null;
   if (cell.id && cell.id.name) name = cell.id.name;
   else if (cell.id && cell.id.id && cell.id.id.name) name = cell.id.id.name;
-  const bodyText = cell.input.substring(cell.body.start, cell.body.end);
+  let bodyText = cell.input.substring(cell.body.start, cell.body.end);
+  const cellReferences = (cell.references || []).map(ref => {
+    if (ref.type === "ViewExpression") {
+      return 'viewof ' + ref.id.name;
+    } else if (ref.type === "MutableExpression") {
+      return 'mutable ' + ref.id.name;
+    } else return ref.name;
+  });
+  let $count = 0;
+  let indexShift = 0;
+  const references = (cell.references || []).map(ref => {
+    if (ref.type === "ViewExpression") {
+      const $string = '$' + $count;
+      $count++;
+      // replace "viewof X" in bodyText with "$($count)"
+      simple(cell.body, {
+        ViewExpression(node) {
+          const start = node.start - cell.body.start;
+          const end = node.end - cell.body.start;
+          bodyText = bodyText.slice(0, start + indexShift) + $string + bodyText.slice(end + indexShift);
+          indexShift += $string.length - (end - start);
+        }
+      }, walk);
+      return $string;
+    } else if (ref.type === "MutableExpression") {
+      const $string = '$' + $count;
+      const $stringValue = $string + '.value';
+      $count++;
+      // replace "mutable Y" in bodyText with "$($count).value"
+      simple(cell.body, {
+        MutableExpression(node) {
+          const start = node.start - cell.body.start;
+          const end = node.end - cell.body.start;
+          bodyText = bodyText.slice(0, start + indexShift) + $stringValue + bodyText.slice(end + indexShift);
+          indexShift += $stringValue.length - (end - start);
+        }
+      }, walk);
+      return $string;
+    } else return ref.name;
+  });
   let code;
   if (cell.body.type !== "BlockStatement") {
     if (cell.async)
       code = `return (async function(){ return (${bodyText});})()`;
     else code = `return (function(){ return (${bodyText});})()`;
   } else code = bodyText;
-  const references = (cell.references || []).map(ref => {
-    if (ref.type === "ViewExpression") throw Error("ViewExpression wat");
-    return ref.name;
-  });
 
   let f;
 
@@ -40,7 +77,7 @@ const createRegularCellDefintion = cell => {
   return {
     cellName: name,
     cellFunction: f,
-    cellReferences: references
+    cellReferences
   };
 };
 const createModuleDefintion = (m, resolveModule) => {
@@ -96,7 +133,15 @@ const createModuleDefintion = (m, resolveModule) => {
           main
             .variable(observer(reference))
             .define(reference, cellReferences, cellFunction);
-          main.variable(null).define(cellName, [reference], Generators.input);
+          main.variable(observer(cellName)).define(cellName, [reference], Generators.input);
+        } else if (cell.id && cell.id.type === "MutableExpression") {
+          const initialName = `initial ${cellName}`;
+          const mutableName = `mutable ${cellName}`;
+          main
+            .variable(null)
+            .define(initialName, cellReferences, cellFunction);
+          main.variable(observer(mutableName)).define(mutableName, [initialName], (_) => new Mutable(_));
+          main.variable(observer(cellName)).define(cellName, [mutableName], _ => _.generator);
         } else {
           main
             .variable(observer(cellName))

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,10 +1,6 @@
 import { parseCell, parseModule, walk } from "@observablehq/parser";
-import { Library } from "@observablehq/runtime";
 import { extractPath } from "./utils";
 import { simple } from 'acorn-walk';
-
-const { Generators, Mutable: constantMutable } = new Library();
-const Mutable = constantMutable();
 
 const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
 const GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
@@ -172,14 +168,14 @@ const createModuleDefintion = (m, resolveModule) => {
           main
             .variable(observer(reference))
             .define(reference, cellReferences, cellFunction);
-          main.variable(observer(cellName)).define(cellName, [reference], Generators.input);
+          main.variable(observer(cellName)).define(cellName, ["Generators", reference], (G, _) => G.input(_));
         } else if (cell.id && cell.id.type === "MutableExpression") {
           const initialName = `initial ${cellName}`;
           const mutableName = `mutable ${cellName}`;
           main
             .variable(null)
             .define(initialName, cellReferences, cellFunction);
-          main.variable(observer(mutableName)).define(mutableName, [initialName], (_) => new Mutable(_));
+          main.variable(observer(mutableName)).define(mutableName, ["Mutable", initialName], (M, _) => new M(_));
           main.variable(observer(cellName)).define(cellName, [mutableName], _ => _.generator);
         } else {
           main

--- a/test/test.html
+++ b/test/test.html
@@ -40,10 +40,29 @@
       }
     }
 
+    viewof x = html\`<input type="range">\`
+
+    y = x * x
+
+    z = viewof x.valueAsNumber + x
+
+    mutable m = 0
+
+    {
+      const button = html\`<button>increment m, decrement x\`;
+      button.onclick = () => {
+        mutable m++;
+        viewof x.value = viewof x.valueAsNumber - 1;
+        viewof x.dispatchEvent(new CustomEvent('input'));
+      };
+      return button;
+    }
+
+    3*m
+
     d3 = require('d3-array')
 
     html\`<img src="https://images.dog.ceo/breeds/dhole/n02115913_4117.jpg" width="100">\`
-
 
     import {ramp} from "@mbostock/color-ramp"
 
@@ -76,6 +95,6 @@
 `);
 
     const rt = new Runtime();
-    rt.module(define, Inspector.into(document.querySelector("#main")));
+    window.MODULE = rt.module(define, Inspector.into(document.querySelector("#main")));
   </script>
 </body>

--- a/test/test.html
+++ b/test/test.html
@@ -92,6 +92,40 @@
     import {chart as histogram} with {localImage as image} from "https://api.observablehq.com/@d3/mona-lisa-histogram.js"
 
     histogram
+
+    import {viewof message} from "https://observablehq.com/@observablehq/introduction-to-views"
+
+    viewof message
+
+    message
+
+    import { wrap } from '8135ff976018a995'
+
+    viewof myA = wrap(html\`<input type="number" value="2">\`)
+
+    import { viewof a as a2, b as b2 } with {
+      viewof myA as a
+    } from '8135ff976018a995'
+
+    viewof a2
+
+    viewof a2 === viewof myA
+
+    a2
+
+    b2
+
+    viewof myB = wrap(html\`<input type="number" value="-20">\`)
+
+    import { viewof a as a3, b as b3 } with { myB as a } from '8135ff976018a995'
+
+    viewof a3
+
+    a3
+
+    myB === a3
+
+    b3
 `);
 
     const rt = new Runtime();

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,9 +334,9 @@ magic-string@^0.25.2:
   dependencies:
     sourcemap-codec "^1.4.4"
 
-"marked@https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f":
+"marked@git+https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f":
   version "0.3.12"
-  resolved "https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f"
+  resolved "git+https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f"
 
 mime@^1.6.0:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,11 @@ acorn-walk@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
+acorn-walk@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
+  integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
+
 acorn@^6.0.4:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"


### PR DESCRIPTION
The first commit 2ef363f is the same as in #6. To reply to your comment from that PR, I would support a request for the `parser` package to export acorn's `simple` (though maybe since `parser` is an acorn plugin they could use peerDependencies instead? not sure...). Also, I guess I could've set the version for `acorn-walk` to the same version that the parser uses, but it slipped my mind...

The second commit 618a215 implements imports for viewof & mutable cells:
- I had to change the code for `specifiers` and `injections` from `map` to a `for...of` loop because viewof and mutable imports add more than one new cell. I was a little unsure about what to do with `import...with` so I did some testing which led to [this issue](https://talk.observablehq.com/t/using-import-with-to-inject-viewof-mutable-cells/2428); Given Mike Bostock's reply there I'm pretty confident that the implementation is correct now.
- I added a new flag `hasInjections` that controls whether to `derive` a new module or not. Previously, the generated `define` function was `derive`-ing for every import, which differs from the behavior on the ObservableHQ site, where only modules that are imported using `with` get `derive`'d.
- I still haven't added any `tape` tests, just some examples from the above forum post in `test.html`.

The third and fourth commits are other tweaks. I noticed that the `define` function is currently using creating its own `Library` for `Generators` (and `Mutable` in my addition). In the third commit 5eb6098, I changed this to just rely on the runtime's builtin module, as in the ES modules served by the Observable API ([example](https://api.observablehq.com/d/7ccad009e4d89969.js?v=3). This is a little more efficient at runtime (as is, the user will have an extra `Library` object from the compiler) and also allows us to move the `runtime` package to the dev dependencies since it's now only used in the tests.

The fourth commit b5482fc is just a style thing, I noticed that the markdown cells labeling the imports had a level of indentation which didn't seem intentional so I removed it. Let me know if I guessed wrong and you want the indentation back.

Feel free to add comments to the code if you have questions!