### PR TITLE
Compiler.notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,42 @@ const runtime = new Runtime();
 const main = runtime.module(define, Inspector.into(document.body));
 ```
 
+<a href="#compile_notebook" name="compile_notebook">#</a>compile.<b>notebook</b>(<i>object</i>)
+
+Returns a define function. `object` is a "notebook JSON object" as used by the
+ObservableHQ notebook app to display notebooks. Such JSON files are served by
+the API endpoint at `https://api.observablehq.com/document/:slug` (see the
+[`observable-client`](https://github.com/mootari/observable-client) for a
+convenient way to authenticate and make requests).
+
+`compile.notebook` requires that `object` has a field named `"nodes"`
+consisting of an array of cell objects. Each of the cell objects must have a
+field `"value"` consisting of a string with the source code for that cell.
+
+The notebook JSON objects also ordinarily contain some other metadata fields,
+e.g. `"id"`, `"slug"`, `"owner"`, etc. which are currently ignored by the
+compiler. Similarly, the cell objects in `"nodes"` ordinarily contain `"id"` and
+`"pinned"` fields which are also unused here.
+
+For example:
+
+```javascript
+const define = compile.notebook({
+  nodes:[
+    { "value": "a = 1" },
+    { "value": "b = 2" },
+    { "value": "c = a + b" }
+  ]
+});
+```
+
+You can now use `define` with the Observable [runtime](https://github.com/observablehq/runtime):
+
+```javascript
+const runtime = new Runtime();
+const main = runtime.module(define, Inspector.into(document.body));
+```
+
 <a href="#compile_cell" name="compile_cell">#</a>compile.<b>cell</b>(<i>contents</i>)
 
 **WARNING** this isn't implemented yet! I'm not 100% sure how to structure it :/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compiler"
   ],
   "dependencies": {
-    "@observablehq/parser": "^1.2.1",
+    "@observablehq/parser": "^2.0.0",
     "acorn-walk": "^7.0.0"
   },
   "devDependencies": {

--- a/test/test_notebook_json.html
+++ b/test/test_notebook_json.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+
+<head>
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="https://cdn.jsdelivr.net/npm/@observablehq/inspector@3/dist/inspector.css"
+  />
+</head>
+<body class="O--body">
+  <div id="main"></div>
+  <script type="module">
+    import {
+      Runtime,
+      Inspector
+    } from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+    import { Compiler } from "/index-esm.js";
+
+    const notebook = ({
+      "id":"test-notebook-json",
+      "creator":{"name":"test author"},
+      "version":1,
+      "title":"Notebook JSON Compile Test",
+      "nodes":[
+        {
+          "id":0,
+          "value":"md`# Notebook JSON Compile Test`",
+          "pinned": false
+        },
+        {
+          "id":1,
+          "value":`{
+      let i = 1;
+      while(i) {
+        yield Promises.tick(100, ++i);
+      }
+    }`,
+          "pinned": false
+        },
+        {
+          "id":2,
+          "value":`viewof x = html\`<input type="range">\``,
+          "pinned": false
+        },
+        {
+          "id":3,
+          "value":"y = x * x",
+          "pinned": false
+        },
+        {
+          "id":4,
+          "value":"z = viewof x.valueAsNumber + x",
+          "pinned": false
+        },
+        {
+          "id":5,
+          "value":"mutable m = 0",
+          "pinned": false
+        },
+        {
+          "id":6,
+          "value":`{
+      const button = html\`<button>increment m, decrement x\`;
+      button.onclick = () => {
+        mutable m++;
+        viewof x.value = viewof x.valueAsNumber - 1;
+        viewof x.dispatchEvent(new CustomEvent('input'));
+      };
+      return button;
+    }`,
+          "pinned": false
+        },
+        {
+          "id":7,
+          "value":`3*m`,
+          "pinned": false
+        },
+        {
+          "id":8,
+          "value":`d3 = require('d3-array')`,
+          "pinned": false
+        },
+        {
+          "id":9,
+          "value":'import {ramp} from "@mbostock/color-ramp"',
+          "pinned": false
+        },
+        {
+          "id":10,
+          "value":`ramp(t => \`hsl(\${t * 360}, 100%, 50%)\`)`,
+          "pinned": false
+        },
+        {
+          "id":11,
+          "value":'import {map} from "@d3/interrupted-sinu-mollweide"',
+          "pinned": false
+        },
+        {
+          "id":12,
+          "value":"map",
+          "pinned": false
+        }
+      ]
+    });
+    const compile = new Compiler();
+    const define = compile.notebook(notebook);
+
+    const rt = new Runtime();
+    window.MODULE = rt.module(define, Inspector.into(document.querySelector("#main")));
+  </script>
+</body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,14 +9,13 @@
   dependencies:
     esm "^3.0.84"
 
-"@observablehq/parser@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@observablehq/parser/-/parser-1.2.1.tgz#e55460d6de0a419235e918f3b9f35659297eeae3"
-  integrity sha512-5RJhh4nsET6l+Ky6ZT0Qa+ts4KZ6L0cbpLGZxxnwICc6eIDA2/UftIhlp7cL3ZYUQuaP8BgCNV/3c8Z9+WaOnQ==
+"@observablehq/parser@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@observablehq/parser/-/parser-2.0.0.tgz#a5649b979fe3e9ab11c6d05109fa97b7ea55ca00"
+  integrity sha512-l3rakWMJK6kQ5vg0xe1nNPw8EkjeSUoyjFVHN1lR+y3/PyoToWBg4fVM+JtupMptLnoxk53laDYS/D7vS1tczQ==
   dependencies:
-    acorn "^6.0.4"
-    acorn-bigint "^0.3.1"
-    acorn-walk "^6.1.1"
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
 
 "@observablehq/runtime@^4.4.4":
   version "4.4.4"
@@ -53,25 +52,10 @@
   dependencies:
     "@types/node" "*"
 
-acorn-bigint@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-bigint/-/acorn-bigint-0.3.1.tgz#edb40a414dcaf5a09c2933db6bed79454b3ff46a"
-  integrity sha512-WT9LheDC4/d/sD/jgC6L5UMq4U9X3KNMy0JrXp/MdJL83ZqcuPQuMkj50beOX0dMub8IoZUYycfN7bIVZuU5zg==
-
-acorn-walk@^6.1.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
-  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
-
 acorn-walk@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.0.0.tgz#c8ba6f0f1aac4b0a9e32d1f0af12be769528f36b"
   integrity sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg==
-
-acorn@^6.0.4:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
 
 acorn@^7.0.0:
   version "7.0.0"
@@ -334,9 +318,9 @@ magic-string@^0.25.2:
   dependencies:
     sourcemap-codec "^1.4.4"
 
-"marked@git+https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f":
+"marked@https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f":
   version "0.3.12"
-  resolved "git+https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f"
+  resolved "https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f"
 
 mime@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
This is a very rough implementation of a function that takes as input a "notebook JSON object" and outputs a define function. This addresses the first part of #5. The main change I made was to factor out the `cellPromise` function from `createModuleDefinition`. So I didn't end up writing a `compile.cell` function.

I also bumped the `@observablehq/parser` version since that's been updated recently to 2.0.0.

I added a new HTML file for testing this function with a translation of some of the test cells in `test.html` to the notebook JSON format.