### PR TITLE
fix: Get imported modules before returning define function

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -208,14 +208,14 @@ const createModuleDefintion = async (
   });
   await Promise.all(importCellsPromise);
 
-  return async function define(runtime, observer) {
+  return function define(runtime, observer) {
     const { cells } = moduleObject;
     const main = runtime.module();
     main.builtin(
       "FileAttachment",
       runtime.fileAttachments(resolveFileAttachments)
     );
-    cells.map(async cell =>
+    cells.map(cell =>
       createCellDefinition(cell, main, observer, dependencyMap)
     );
   };

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -7,11 +7,6 @@ const GeneratorFunction = Object.getPrototypeOf(function*() {}).constructor;
 const AsyncGeneratorFunction = Object.getPrototypeOf(async function*() {})
   .constructor;
 
-const createImportCellDefintion = async (cell, resolveModule) => {
-  const source = cell.body.source.value;
-  const from = await resolveModule(source);
-  return { from };
-};
 const createRegularCellDefintion = cell => {
   let name = null;
   if (cell.id && cell.id.name) name = cell.id.name;
@@ -90,7 +85,7 @@ const createRegularCellDefintion = cell => {
     cellReferences
   };
 };
-const cellPromise = async (cell, main, observer, resolveModule) => {
+const createCellDefinition = (cell, main, observer, dependencyMap) => {
   if (cell.body.type === "ImportDeclaration") {
     const specifiers = [];
     if (cell.body.specifiers)
@@ -150,13 +145,11 @@ import {${specifiers
       }from "${cell.body.source.value}"
 ~~~`
     );
-    const { from } = await createImportCellDefintion(cell, resolveModule).catch(
-      err => {
-        throw Error("Error defining import cell", err);
-      }
+
+    const other = main._runtime.module(
+      dependencyMap.get(cell.body.source.value)
     );
 
-    const other = main._runtime.module(from);
     if (hasInjections) {
       const child = other.derive(injections, main);
       specifiers.map(specifier => {
@@ -198,19 +191,33 @@ import {${specifiers
     }
   }
 };
-const createModuleDefintion = (m, resolveModule, resolveFileAttachments) => {
+const createModuleDefintion = async (
+  moduleObject,
+  resolveModule,
+  resolveFileAttachments
+) => {
+  const dependencyMap = new Map();
+
+  const importCells = moduleObject.cells.filter(
+    cell => cell.body.type === "ImportDeclaration"
+  );
+
+  const importCellsPromise = importCells.map(async cell => {
+    const fromModule = await resolveModule(cell.body.source.value);
+    dependencyMap.set(cell.body.source.value, fromModule);
+  });
+  await Promise.all(importCellsPromise);
+
   return async function define(runtime, observer) {
-    const { cells } = m;
+    const { cells } = moduleObject;
     const main = runtime.module();
     main.builtin(
       "FileAttachment",
       runtime.fileAttachments(resolveFileAttachments)
     );
-    const cellsPromise = cells.map(async cell =>
-      cellPromise(cell, main, observer, resolveModule)
+    cells.map(async cell =>
+      createCellDefinition(cell, main, observer, dependencyMap)
     );
-
-    await Promise.all(cellsPromise);
   };
 };
 
@@ -232,30 +239,24 @@ export class Compiler {
   cell(text) {
     throw Error(`compile.cell not implemented yet`);
   }
-  module(text) {
+  async module(text) {
     const m1 = parseModule(text);
-    return createModuleDefintion(m1, this.resolve, this.resolveFileAttachments);
+    return await createModuleDefintion(
+      m1,
+      this.resolve,
+      this.resolveFileAttachments
+    );
   }
-  notebook(obj) {
+  async notebook(obj) {
     const cells = obj.nodes.map(({ value }) => {
       const cell = parseCell(value);
       cell.input = value;
       return cell;
     });
-    const resolve = this.resolve;
-    const resolveFileAttachments = this.resolveFileAttachments;
-
-    return async function define(runtime, observer) {
-      const main = runtime.module();
-      main.builtin(
-        "FileAttachment",
-        runtime.fileAttachments(resolveFileAttachments)
-      );
-      const cellsPromise = cells.map(async cell =>
-        cellPromise(cell, main, observer, resolve)
-      );
-
-      await Promise.all(cellsPromise);
-    };
+    return await createModuleDefintion(
+      { cells },
+      this.resolve,
+      this.resolveFileAttachments
+    );
   }
 }

--- a/test/compiler-test.js
+++ b/test/compiler-test.js
@@ -5,7 +5,7 @@ const compiler = require("../dist/index");
 test("compiler", async t => {
   const rt = new runtime.Runtime();
   const compile = new compiler.Compiler();
-  const define = compile.module(`
+  const define = await compile.module(`
 a = 1
 
 b = 2

--- a/test/test.html
+++ b/test/test.html
@@ -18,7 +18,9 @@
     import { Compiler } from "/dist/index-esm.js";
 
     const compile = new Compiler();
-    const define = compile.module(`
+    compile
+      .module(
+        `
     a = 1
 
     b = 2
@@ -129,9 +131,14 @@
 
     attached = (await import(await FileAttachment("/test/executable_attachment.js").url())).html
 
-`);
-
-    const rt = new Runtime();
-    window.MODULE = rt.module(define, Inspector.into(document.querySelector("#main")));
+`
+      )
+      .then(define => {
+        const rt = new Runtime();
+        window.MODULE = rt.module(
+          define,
+          Inspector.into(document.querySelector("#main"))
+        );
+      });
   </script>
 </body>

--- a/test/test_notebook_json.html
+++ b/test/test_notebook_json.html
@@ -17,50 +17,50 @@
     } from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4.6.4/dist/runtime.js";
     import { Compiler } from "/dist/index-esm.js";
 
-    const notebook = ({
-      "id":"test-notebook-json",
-      "creator":{"name":"test author"},
-      "version":1,
-      "title":"Notebook JSON Compile Test",
-      "nodes":[
+    const notebook = {
+      id: "test-notebook-json",
+      creator: { name: "test author" },
+      version: 1,
+      title: "Notebook JSON Compile Test",
+      nodes: [
         {
-          "id":0,
-          "value":"md`# Notebook JSON Compile Test`",
-          "pinned": false
+          id: 0,
+          value: "md`# Notebook JSON Compile Test`",
+          pinned: false
         },
         {
-          "id":1,
-          "value":`{
+          id: 1,
+          value: `{
       let i = 1;
       while(i) {
         yield Promises.tick(100, ++i);
       }
     }`,
-          "pinned": false
+          pinned: false
         },
         {
-          "id":2,
-          "value":`viewof x = html\`<input type="range">\``,
-          "pinned": false
+          id: 2,
+          value: `viewof x = html\`<input type="range">\``,
+          pinned: false
         },
         {
-          "id":3,
-          "value":"y = x * x",
-          "pinned": false
+          id: 3,
+          value: "y = x * x",
+          pinned: false
         },
         {
-          "id":4,
-          "value":"z = viewof x.valueAsNumber + x",
-          "pinned": false
+          id: 4,
+          value: "z = viewof x.valueAsNumber + x",
+          pinned: false
         },
         {
-          "id":5,
-          "value":"mutable m = 0",
-          "pinned": false
+          id: 5,
+          value: "mutable m = 0",
+          pinned: false
         },
         {
-          "id":6,
-          "value":`{
+          id: 6,
+          value: `{
       const button = html\`<button>increment m, decrement x\`;
       button.onclick = () => {
         mutable m++;
@@ -69,49 +69,52 @@
       };
       return button;
     }`,
-          "pinned": false
+          pinned: false
         },
         {
-          "id":7,
-          "value":`3*m`,
-          "pinned": false
+          id: 7,
+          value: `3*m`,
+          pinned: false
         },
         {
-          "id":8,
-          "value":`d3 = require('d3-array')`,
-          "pinned": false
+          id: 8,
+          value: `d3 = require('d3-array')`,
+          pinned: false
         },
         {
-          "id":9,
-          "value":'import {ramp} from "@mbostock/color-ramp"',
-          "pinned": false
+          id: 9,
+          value: 'import {ramp} from "@mbostock/color-ramp"',
+          pinned: false
         },
         {
-          "id":10,
-          "value":`ramp(t => \`hsl(\${t * 360}, 100%, 50%)\`)`,
-          "pinned": false
+          id: 10,
+          value: `ramp(t => \`hsl(\${t * 360}, 100%, 50%)\`)`,
+          pinned: false
         },
         {
-          "id":11,
-          "value":'import {map} from "@d3/interrupted-sinu-mollweide"',
-          "pinned": false
+          id: 11,
+          value: 'import {map} from "@d3/interrupted-sinu-mollweide"',
+          pinned: false
         },
         {
-          "id":12,
-          "value":"map",
-          "pinned": false
+          id: 12,
+          value: "map",
+          pinned: false
         },
         {
-          "id":13,
-          "value":`attached = (await import(await FileAttachment("/test/executable_attachment.js").url())).html`,
-          "pinned": false
+          id: 13,
+          value: `attached = (await import(await FileAttachment("/test/executable_attachment.js").url())).html`,
+          pinned: false
         }
       ]
-    });
+    };
     const compile = new Compiler();
-    const define = compile.notebook(notebook);
-
-    const rt = new Runtime();
-    window.MODULE = rt.module(define, Inspector.into(document.querySelector("#main")));
+    compile.notebook(notebook).then(define => {
+      const rt = new Runtime();
+      window.MODULE = rt.module(
+        define,
+        Inspector.into(document.querySelector("#main"))
+      );
+    });
   </script>
 </body>


### PR DESCRIPTION
This PR does a few things, sorry for the big file changes:

1. Style fixes - my code editor has builtin prettier formatting, so sorry about that... I wouldve added a `.prettierrc` but since the codebase is small, idk how effective it'd be
2. `cellsPromise` -> `createCellDefinition`. 
3. cleaned up `compile.notebook` to use `createModuleDefintion`. Both functions were doing the same thing before.
4. (biggest change) Dynamically import all the external modules before defining "regular" cells. 

This change was needed because "regular" cells that depended on imported cells would error out saying `importCell is not defined` while the imported cells were being resolved. For example, say there was this module:

```js
import {x} from '@user/big-notebook'

y = `x is ${x}`
```

So, the compiler would parse this module, then do a `createCellDefintion` on each cell. Creating the cell definition for x would take a long time - since it would have to `import()` the `@user/big-notebook` ES module, then it would finally call `module.import(x, other)`. This is an async process.

For `y`, on the other hand, that would be defined *before* `module.import(x, other}` would be called, since regular cell definitions could be synchronous. So, `module.define(y, ["x"], x => 'x is ${x}')` would be executed, `x` wouldnt be defined yet, throwing the `x is not defined` error.

You could see this in our `test.html` pages - here's an example, notice how when I do a hard refresh, the `RuntimeError: x is not defined` error is throw for cells that depend on imported cells.

![unofficial-observablehq-compiler-demo surge sh_test_test html](https://user-images.githubusercontent.com/15178711/68978719-65b1a180-07b0-11ea-8bc6-118b948f5b7d.gif)

So, my solution is that *before* we return the `async function define(runtime, observer)` in `createModuleDefintion`, we first loop through all the import cells, resolve the modules that they depend on, then save that in a map. For example, `dependencyMap` could look like:

```
{
    "@asg017/notebook": async function define(){},
     "@user/module": async function define(){},
}
```

So now, when call `createCellDefintion` on all the cells, there's no need for import cells to by asynchronous anymore (since they can just call `dependencyMap.get(name)`), removing the error. Here's what the page looks like now, notice how there's no `RuntimeError` when I refresh: 

![54 186 152 31_3000_test_test html - Edited](https://user-images.githubusercontent.com/15178711/68979283-f6d54800-07b1-11ea-97a8-ce53b42315ee.gif)


Here are 2 side effects to this:

1. All imported cells are imported by default, even if they, or their transitive outputs, are not used. However, this same behavior also occurs in Observable ESM define functions, like here: https://api.observablehq.com/@observablehq/introduction-to-imports.js?v=3 (since all the imports, `define1`-`define7` are imported, no matter how they are used or not)
2. `compile.module` and `compile.notebook` now return promises, making them async. I don't think this is a big deal, though

@bryangingechen would love to hear your thoughts on these changes! It (kindof) breaks the old `compile.module` and `compile.notebook`  APIs, since they are now asynchronous, but I dont think that's too big of an issue. (and sorry for the large diff!)