### PR TITLE
fix(index.html,README): async changes / fix(compiler): only resolve imports once / refactor(compiler): split out parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
     import { Compiler } from "https://cdn.jsdelivr.net/npm/@alex.garcia/unofficial-observablehq-compiler/dist/index-esm.js";
 
     const compile = new Compiler();
-    const define = compile.module(`
+    compile.module(`
 
     md\`# Hello, Unofficial ObservableHQ compiler!
-    
+
 This is a landing page for demos of the [Unofficial ObservableHQ compiler](https://github.com/asg017/unofficial-observablehq-compiler). This site is mainly meant to ensure that the compiler is working in an browser environment, with these files:
 
 - [test.html](/test/test.html)
@@ -38,7 +38,7 @@ This is a landing page for demos of the [Unofficial ObservableHQ compiler](https
 - [test_cell.html](/test/test_cell.html)
 
 
-More information about the compiler can be found in the project repo, or in [this Observable notebook](https://observablehq.com/@asg017/an-unofficial-observablehq-compiler). 
+More information about the compiler can be found in the project repo, or in [this Observable notebook](https://observablehq.com/@asg017/an-unofficial-observablehq-compiler).
 
 
     (P.S. - this page was made with the compiler!)
@@ -46,12 +46,12 @@ More information about the compiler can be found in the project repo, or in [thi
 
 
 
-`);
-
+`).then(define => {
     const rt = new Runtime();
     window.MODULE = rt.module(
       define,
       Inspector.into(document.querySelector("#main"))
     );
+  });
   </script>
 </body>


### PR DESCRIPTION
Here are a few preparatory changes I made while working on the upcoming ES module PR  (I hope to push that either later today or tomorrow). In hindsight, this could probably be three separate PRs, sorry!

- The changes in `index.html` (db2e4e9) and `README.md` (ac97902) are fixes related to async changes in #11 and #12. In the README, I just added `await` in a bunch of places where it looked like it was now necessary. I didn't test the snippets separately though, so it'd be good if you could make sure I didn't screw up there.

- There are a few changes to `compiler.js` (they're unfortunately squished into one commit ac97902):
  - From lines 1-173 (in the new version), I did a slight refactor to split out some parsing code from the code which creates the `define` function. The new functions will be used in the upcoming ES module compilation PR. 
  - In lines 181 and 183 and 263-264, I changed some `.map()` calls which didn't return anything to `for ... of` loops. 
  - In lines 240-253 I changed things so that imported modules are only resolved once.