### PR TITLE
feat(compiler): generate source code for ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ This is a landing page for demos of the [Unofficial ObservableHQ compiler](https
 - [test.html](/test/test.html)
 - [test_notebook_json.html](/test/test_notebook_json.html)
 - [test_cell.html](/test/test_cell.html)
+- [test_ES_module.html](/test/test_ES_module.html)
 
 
 More information about the compiler can be found in the project repo, or in [this Observable notebook](https://observablehq.com/@asg017/an-unofficial-observablehq-compiler).

--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
     import { Compiler } from "https://cdn.jsdelivr.net/npm/@alex.garcia/unofficial-observablehq-compiler/dist/index-esm.js";
 
     const compile = new Compiler();
-    const define = compile.module(`
+    compile.module(`
 
     md\`# Hello, Unofficial ObservableHQ compiler!
-    
+
 This is a landing page for demos of the [Unofficial ObservableHQ compiler](https://github.com/asg017/unofficial-observablehq-compiler). This site is mainly meant to ensure that the compiler is working in an browser environment, with these files:
 
 - [test.html](/test/test.html)
@@ -38,7 +38,7 @@ This is a landing page for demos of the [Unofficial ObservableHQ compiler](https
 - [test_cell.html](/test/test_cell.html)
 
 
-More information about the compiler can be found in the project repo, or in [this Observable notebook](https://observablehq.com/@asg017/an-unofficial-observablehq-compiler). 
+More information about the compiler can be found in the project repo, or in [this Observable notebook](https://observablehq.com/@asg017/an-unofficial-observablehq-compiler).
 
 
     (P.S. - this page was made with the compiler!)
@@ -46,12 +46,12 @@ More information about the compiler can be found in the project repo, or in [thi
 
 
 
-`);
-
+`).then(define => {
     const rt = new Runtime();
     window.MODULE = rt.module(
       define,
       Inspector.into(document.querySelector("#main"))
     );
+  });
   </script>
 </body>

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -244,7 +244,8 @@ const createModuleDefintion = async (
       filteredImportCells.has(body.source.value)
     )
       return false;
-    filteredImportCells.add(cell.body.source.value);
+    filteredImportCells.add(body.source.value);
+    return true;
   });
 
   const dependencyMap = new Map();

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -265,20 +265,156 @@ const createModuleDefintion = async (
   };
 };
 
+const ESMImports = (moduleObject, resolvePath) => {
+  const importMap = new Map();
+  let importSrc = "";
+  let j = 0;
+
+  for (const { body } of moduleObject.cells) {
+    if (body.type !== "ImportDeclaration" || importMap.has(body.source.value))
+      continue;
+
+    const defineName = `define${++j}`;
+    const fromPath = resolvePath(body.source.value);
+    importMap.set(body.source.value, { defineName, fromPath });
+    importSrc += `import ${defineName} from "${fromPath}";\n`;
+  }
+
+  if (importSrc.length) importSrc += "\n";
+  return { importSrc, importMap };
+};
+
+const ESMAttachments = (moduleObject, resolveFileAttachments) => {
+  const attachmentMapEntries = [];
+  // loop over cells with fileAttachments
+  for (const cell of moduleObject.cells) {
+    if (cell.fileAttachments.size === 0) continue;
+    // add filenames and resolved URLs to array
+    for (const file of cell.fileAttachments.keys())
+      attachmentMapEntries.push([file, resolveFileAttachments(file)]);
+  }
+
+  return attachmentMapEntries.length === 0
+    ? ""
+    : `  const fileAttachments = new Map(${JSON.stringify(
+        attachmentMapEntries
+      )});
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));`;
+};
+
+const ESMVariables = (moduleObject, importMap) => {
+  let childJ = 0;
+  return moduleObject.cells
+    .map(cell => {
+      let src = "";
+
+      if (cell.body.type === "ImportDeclaration") {
+        const {
+          specifiers,
+          hasInjections,
+          injections,
+          importString
+        } = setupImportCell(cell);
+        // this will display extra names for viewof / mutable imports (for now?)
+        src +=
+          `  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+${importString}
+~~~\`
+  );` + "\n";
+        // name imported notebook define functions
+        const childName = `child${++childJ}`;
+        src += `  const ${childName} = runtime.module(${
+          importMap.get(cell.body.source.value).defineName
+        })${
+          hasInjections ? `.derive(${JSON.stringify(injections)}, main)` : ""
+        };
+${specifiers
+  .map(
+    specifier =>
+      `  main.import("${specifier.name}", "${specifier.alias}", ${childName});`
+  )
+  .join("\n")}`;
+      } else {
+        const {
+          cellName,
+          references,
+          bodyText,
+          cellReferences
+        } = setupRegularCell(cell);
+
+        const cellNameString = cellName ? `"${cellName}"` : "";
+        const referenceString = references.join(",");
+        let code = "";
+        if (cell.body.type !== "BlockStatement")
+          code = `{return(
+${bodyText}
+)}`;
+        else code = "\n" + bodyText + "\n";
+        const cellReferencesString = cellReferences.length
+          ? JSON.stringify(cellReferences) + ", "
+          : "";
+        let cellFunction = "";
+        if (cell.generator && cell.async)
+          cellFunction = `async function*(${referenceString})${code}`;
+        else if (cell.async)
+          cellFunction = `async function(${referenceString})${code}`;
+        else if (cell.generator)
+          cellFunction = `function*(${referenceString})${code}`;
+        else cellFunction = `function(${referenceString})${code}`;
+
+        if (cell.id && cell.id.type === "ViewExpression") {
+          const reference = `"viewof ${cellName}"`;
+          src += `  main.variable(observer(${reference})).define(${reference}, ${cellReferencesString}${cellFunction});
+  main.variable(observer("${cellName}")).define("${cellName}", ["Generators", ${reference}], (G, _) => G.input(_));`;
+        } else if (cell.id && cell.id.type === "MutableExpression") {
+          const initialName = `"initial ${cellName}"`;
+          const mutableName = `"mutable ${cellName}"`;
+          src += `  main.define(${initialName}, ${cellReferencesString}${cellFunction});
+  main.variable(observer(${mutableName})).define(${mutableName}, ["Mutable", ${initialName}], (M, _) => new M(_));
+  main.variable(observer("${cellName}")).define("${cellName}", [${mutableName}], _ => _.generator);`;
+        } else {
+          src += `  main.variable(observer(${cellNameString})).define(${
+            cellName ? cellNameString + ", " : ""
+          }${cellReferencesString}${cellFunction});`;
+        }
+      }
+      return src;
+    })
+    .join("\n");
+};
+const createESModule = (moduleObject, resolvePath, resolveFileAttachments) => {
+  const { importSrc, importMap } = ESMImports(moduleObject, resolvePath);
+  return `${importSrc}export default function define(runtime, observer) {
+  const main = runtime.module();
+${ESMAttachments(moduleObject, resolveFileAttachments)}
+${ESMVariables(moduleObject, importMap) || ""}
+  return main;
+}`;
+};
+
 const defaultResolver = async path => {
   const source = extractPath(path);
   return import(`https://api.observablehq.com/${source}.js?v=3`).then(
     m => m.default
   );
 };
+const defaultResolvePath = path => {
+  const source = extractPath(path);
+  return `https://api.observablehq.com/${source}.js?v=3`;
+};
 
 export class Compiler {
   constructor(
     resolve = defaultResolver,
-    resolveFileAttachments = name => name
+    resolveFileAttachments = name => name,
+    resolvePath = defaultResolvePath
   ) {
     this.resolve = resolve;
     this.resolveFileAttachments = resolveFileAttachments;
+    this.resolvePath = resolvePath;
   }
   async cell(text) {
     const cell = parseCell(text);
@@ -315,6 +451,23 @@ export class Compiler {
     return await createModuleDefintion(
       { cells },
       this.resolve,
+      this.resolveFileAttachments
+    );
+  }
+
+  moduleToESModule(text) {
+    const m1 = parseModule(text);
+    return createESModule(m1, this.resolvePath, this.resolveFileAttachments);
+  }
+  notebookToESModule(obj) {
+    const cells = obj.nodes.map(({ value }) => {
+      const cell = parseCell(value);
+      cell.input = value;
+      return cell;
+    });
+    return createESModule(
+      { cells },
+      this.resolvePath,
       this.resolveFileAttachments
     );
   }

--- a/test/compileESModule-test.js
+++ b/test/compileESModule-test.js
@@ -1,0 +1,286 @@
+const test = require("tape");
+const compiler = require("../dist/index");
+
+test("ES module: simple", async t => {
+  const compile = new compiler.Compiler();
+  const src = compile.moduleToESModule(`
+a = 1
+
+b = 2
+
+c = a + b
+
+d = {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+
+{
+  await d;
+}
+
+viewof e = {
+  let output = {};
+  let listeners = [];
+  output.value = 10;
+  output.addEventListener = (listener) => listeners.push(listener);;
+  output.removeEventListener = (listener) => {
+    listeners = listeners.filter(l => l !== listener);
+  };
+  return output;
+}
+    `);
+  t.equal(src, `export default function define(runtime, observer) {
+  const main = runtime.module();
+
+  main.variable(observer("a")).define("a", function(){return(
+1
+)});
+  main.variable(observer("b")).define("b", function(){return(
+2
+)});
+  main.variable(observer("c")).define("c", ["a","b"], function(a,b){return(
+a + b
+)});
+  main.variable(observer("d")).define("d", function*()
+{
+  yield 1;
+  yield 2;
+  yield 3;
+}
+);
+  main.variable(observer()).define(["d"], async function(d)
+{
+  await d;
+}
+);
+  main.variable(observer("viewof e")).define("viewof e", function()
+{
+  let output = {};
+  let listeners = [];
+  output.value = 10;
+  output.addEventListener = (listener) => listeners.push(listener);;
+  output.removeEventListener = (listener) => {
+    listeners = listeners.filter(l => l !== listener);
+  };
+  return output;
+}
+);
+  main.variable(observer("e")).define("e", ["Generators", "viewof e"], (G, _) => G.input(_));
+  return main;
+}`);
+
+  t.end();
+});
+
+test("ES module: imports", async t => {
+  const compile = new compiler.Compiler();
+  const src = compile.moduleToESModule(`import {a} from "b"
+b = {
+  return 3*a
+}
+import {c as bc} from "b"
+import {d} with {b as cb} from "c"
+`);
+
+  t.equal(src, `import define1 from "https://api.observablehq.com/b.js?v=3";
+import define2 from "https://api.observablehq.com/c.js?v=3";
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {a as a} from "b"
+~~~\`
+  );
+  const child1 = runtime.module(define1);
+  main.import("a", "a", child1);
+  main.variable(observer("b")).define("b", ["a"], function(a)
+{
+  return 3*a
+}
+);
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {c as bc} from "b"
+~~~\`
+  );
+  const child2 = runtime.module(define1);
+  main.import("c", "bc", child2);
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {d as d} with {b as cb} from "c"
+~~~\`
+  );
+  const child3 = runtime.module(define2).derive([{"name":"b","alias":"cb"}], main);
+  main.import("d", "d", child3);
+  return main;
+}`);
+
+  t.end();
+});
+
+
+test("ES module: custom resolvePath function", async t => {
+  const resolvePath = name => `https://gist.github.com/${name}`;
+  const compile = new compiler.Compiler(undefined, undefined, resolvePath);
+  const src = compile.moduleToESModule(`import {a} from "b"
+b = {
+  return 3*a
+}
+import {c as bc} from "b"
+import {d} with {b as cb} from "c"
+`);
+
+  t.equal(src, `import define1 from "https://gist.github.com/b";
+import define2 from "https://gist.github.com/c";
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {a as a} from "b"
+~~~\`
+  );
+  const child1 = runtime.module(define1);
+  main.import("a", "a", child1);
+  main.variable(observer("b")).define("b", ["a"], function(a)
+{
+  return 3*a
+}
+);
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {c as bc} from "b"
+~~~\`
+  );
+  const child2 = runtime.module(define1);
+  main.import("c", "bc", child2);
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {d as d} with {b as cb} from "c"
+~~~\`
+  );
+  const child3 = runtime.module(define2).derive([{"name":"b","alias":"cb"}], main);
+  main.import("d", "d", child3);
+  return main;
+}`);
+
+  t.end();
+});
+
+test("ES module: viewof + mutable", async t => {
+  const compile = new compiler.Compiler();
+  const src = compile.moduleToESModule(`viewof a = {
+  const div = html\`\`;
+  div.value = 3;
+  return div;
+}
+mutable b = 3
+{
+  return b*b
+}
+d = {
+  mutable b++;
+  return a + b;
+}
+import {viewof v as w, mutable m} from "notebook"`);
+
+  t.equal(src, `import define1 from "https://api.observablehq.com/notebook.js?v=3";
+
+export default function define(runtime, observer) {
+  const main = runtime.module();
+
+  main.variable(observer("viewof a")).define("viewof a", ["html"], function(html)
+{
+  const div = html\`\`;
+  div.value = 3;
+  return div;
+}
+);
+  main.variable(observer("a")).define("a", ["Generators", "viewof a"], (G, _) => G.input(_));
+  main.define("initial b", function(){return(
+3
+)});
+  main.variable(observer("mutable b")).define("mutable b", ["Mutable", "initial b"], (M, _) => new M(_));
+  main.variable(observer("b")).define("b", ["mutable b"], _ => _.generator);
+  main.variable(observer()).define(["b"], function(b)
+{
+  return b*b
+}
+);
+  main.variable(observer("d")).define("d", ["mutable b","a","b"], function($0,a,b)
+{
+  $0.value++;
+  return a + b;
+}
+);
+  main.variable(observer()).define(
+    null,
+    ["md"],
+    md => md\`~~~javascript
+import {viewof v as viewof w, v as w, mutable m as mutable m, m as m} from "notebook"
+~~~\`
+  );
+  const child1 = runtime.module(define1);
+  main.import("viewof v", "viewof w", child1);
+  main.import("v", "w", child1);
+  main.import("mutable m", "mutable m", child1);
+  main.import("m", "m", child1);
+  return main;
+}`);
+
+  t.end();
+});
+
+test("ES module: FileAttachment", async t => {
+  const compile = new compiler.Compiler();
+  const src = compile.moduleToESModule(`md\`Here's a cell with a file attachment! <img src="\${await FileAttachment("image.png").url()}">\``);
+
+  t.equal(src, `export default function define(runtime, observer) {
+  const main = runtime.module();
+  const fileAttachments = new Map([["image.png","image.png"]]);
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+  main.variable(observer()).define(["md","FileAttachment"], async function(md,FileAttachment){return(
+md\`Here's a cell with a file attachment! <img src="\${await FileAttachment("image.png").url()}">\`
+)});
+  return main;
+}`);
+
+  t.end();
+});
+
+test("ES module: custom fileAttachmentsResolve", async t => {
+  const fileAttachmentsResolve = name => `https://example.com/${name}`;
+  const compile = new compiler.Compiler(undefined, fileAttachmentsResolve);
+  const src = compile.moduleToESModule(`md\`Here's a cell with a file attachment! <img src="\${await FileAttachment("image.png").url()}">\``);
+
+  t.equal(src, `export default function define(runtime, observer) {
+  const main = runtime.module();
+  const fileAttachments = new Map([["image.png","https://example.com/image.png"]]);
+  main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));
+  main.variable(observer()).define(["md","FileAttachment"], async function(md,FileAttachment){return(
+md\`Here's a cell with a file attachment! <img src="\${await FileAttachment("image.png").url()}">\`
+)});
+  return main;
+}`);
+
+  t.end();
+});
+
+

--- a/test/test_ES_module.html
+++ b/test/test_ES_module.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+
+<head>
+  <link
+    rel="stylesheet"
+    type="text/css"
+    href="https://cdn.jsdelivr.net/npm/@observablehq/inspector@3/dist/inspector.css"
+  />
+</head>
+<body class="O--body">
+  <div id="main"></div>
+  <script type="module">
+    import {
+      Runtime,
+      Inspector
+    } from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+    import { Compiler } from "/dist/index-esm.js";
+
+    const compile = new Compiler();
+    const src = compile
+      .moduleToESModule(
+        `
+    a = 1
+
+    b = 2
+
+    c = a + b
+
+    md\` This cell contains **markdown**
+
+- ~isn't~
+- *this*
+- [cool](https://www.youtube.com/watch?v=dQw4w9WgXcQ)?
+
+    \`
+
+    {
+      let i = 1;
+      while(i) {
+        yield Promises.tick(100, ++i);
+      }
+    }
+
+    viewof x = html\`<input type="range">\`
+
+    y = x * x
+
+    z = viewof x.valueAsNumber + x
+
+    mutable m = 0
+
+    {
+      const button = html\`<button>increment m, decrement x\`;
+      button.onclick = () => {
+        mutable m++;
+        viewof x.value = viewof x.valueAsNumber - 1;
+        viewof x.dispatchEvent(new CustomEvent('input'));
+      };
+      return button;
+    }
+
+    3*m
+
+    d3 = require('d3-array')
+
+    html\`<img src="https://images.dog.ceo/breeds/dhole/n02115913_4117.jpg" width="100">\`
+
+    import {ramp} from "@mbostock/color-ramp"
+
+    ramp(t => \`hsl(\${t * 360}, 100%, 50%)\`)
+
+    import {map} from "@d3/interrupted-sinu-mollweide"
+
+    map
+
+    import {giraffe} from "https://observablehq.com/@lemonnish/animated-canvas-layers"
+
+    giraffe
+
+    import {chart} from "d43fa2a122cc9fbf"
+
+    chart
+
+    localImage = new Promise((resolve, reject) => {
+      const image = new Image;
+      image.style = "height: 60px; display: block;";
+      image.crossOrigin = "anonymous";
+      image.onerror = reject;
+      image.onload = () => resolve(image);
+      image.src = "https://avatars0.githubusercontent.com/u/15178711?v=4";
+    })
+
+    import {chart as histogram} with {localImage as image} from "https://api.observablehq.com/@d3/mona-lisa-histogram.js"
+
+    histogram
+
+    import {viewof message} from "https://observablehq.com/@observablehq/introduction-to-views"
+
+    viewof message
+
+    message
+
+    import { wrap } from '8135ff976018a995'
+
+    viewof myA = wrap(html\`<input type="number" value="2">\`)
+
+    import { viewof a as a2, b as b2 } with {
+      viewof myA as a
+    } from '8135ff976018a995'
+
+    viewof a2
+
+    viewof a2 === viewof myA
+
+    a2
+
+    b2
+
+    viewof myB = wrap(html\`<input type="number" value="-20">\`)
+
+    import { viewof a as a3, b as b3 } with { myB as a } from '8135ff976018a995'
+
+    viewof a3
+
+    a3
+
+    myB === a3
+
+    b3
+
+    // the executable attachment in test.html doesn't work since this is inside a data URL
+    attached = (await FileAttachment("https://raw.githubusercontent.com/asg017/unofficial-observablehq-compiler/master/README.md").text())
+
+`
+      );
+      console.log(src);
+
+      // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
+      // possibly deprecated...
+      function utoa(str) {
+          return window.btoa(unescape(encodeURIComponent(str)));
+      }
+
+      import(`data:text/javascript;base64,${utoa(src)}`)
+      .then((module) => {
+        const rt = new Runtime();
+        window.MODULE = rt.module(
+          module.default,
+          Inspector.into(document.querySelector("#main"))
+        );
+      });
+  </script>
+</body>


### PR DESCRIPTION
Addresses part 2 of #5 . Contains commits from #14 (see the comments there for details on the changes in the first 3 commits). The main new commits are 077aa29 and ac7f551. 87dd806 is a bugfix for an issue with 6e140ee.

This adds two new methods to the `Compiler` class, `.moduleToESModule()` and `notebookToESModule`, which are modeled after `.module()` and `.notebook()`, respectively. The `Compiler` class gets a new optional parameter `resolvePath`, which is a "string" version of `resolve`.

I added some tests in `test/compileESModule-test.js` that check the output strings in a number of cases, and I also used [a trick from my old V1 compiler notebook](https://observablehq.com/@bryangingechen/from-raw-notebook-source-to-observable-runtime-v1-modules#moduleScratchNew) to write a browser test in `test/test_ES_module.html` (we generate the source of the ES module and then dynamically import it from a data URL).