### PR TITLE
Fix the PR Github Action.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,4 +21,9 @@ jobs:
       with:
           github-token: ${{github.token}}
           script: |
-            await github.issues.createComment({...context.issue, body: 'New demo site for this PR deployed to [unofficial-observablehq-compiler-demo-${{ github.event.number }}.surge.sh](https://unofficial-observablehq-compiler-demo-${{ github.event.number }}.surge.sh) !'})
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'New demo site for this PR deployed to [unofficial-observablehq-compiler-demo-${{ github.event.number }}.surge.sh](https://unofficial-observablehq-compiler-demo-${{ github.event.number }}.surge.sh) !'
+            })


### PR DESCRIPTION
Github API changed for some reason, so the Github Action  that was in place that runs on every PR couldn't leave a comment, breaking the build. This fixes that.

(if the build passes imma just merge it in, this PR is mainly a test-ception)