### PR TITLE
Fix readme option formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ and this [test page](https://github.com/asg017/unofficial-observablehq-compiler/
 
 `Interpreter` is a class that encompasses all logic to interpret Observable js code. _params_ is an optional object with the following allowed configuration:
 
-`resolveImportPath(path, specifers)`: An async function that resolves to the `define` definition for a notebook. _path_ is the string provided in the import statement, and _specifiers_ is a array of string if the imported cell name specifiers in the statement (cells inside `import {...}`). _specifiers_ is useful when implementing tree-shaking. For example, `import {chart as CHART} from "@d3/bar-chart"` would supply `path="@d3/bar-chart"` and `specifiers=["chart"]`. Default imports from observablehq.com, eg `https://api.observablehq.com/@d3/bar-chart.js?v=3`
-`resolveFileAttachments`: A function that, given the name of a FileAttachment, returns the URL that the FileAttachment will be fetched from. Defaults to `name => name`.
-`defineImportMarkdown`: A boolean, whether to define a markdown description cell for imports in the notebook. Defaults true.
-`observeViewofValues`: A boolean, whether to pass in an _observer_ for the value of viewof cells.
-`module`: A default Observable runtime [module](https://github.com/observablehq/runtime#modules) that will be used in operations such as `.cell` and `.module`, if no other module is passed in.
-`observer`: A default Observable runtime [observer](https://github.com/observablehq/runtime#observer) that will be used in operations such as `.cell` and `.module`, if no other observer is passed in.
+- `resolveImportPath(path, specifers)`: An async function that resolves to the `define` definition for a notebook. _path_ is the string provided in the import statement, and _specifiers_ is a array of string if the imported cell name specifiers in the statement (cells inside `import {...}`). _specifiers_ is useful when implementing tree-shaking. For example, `import {chart as CHART} from "@d3/bar-chart"` would supply `path="@d3/bar-chart"` and `specifiers=["chart"]`. Default imports from observablehq.com, eg `https://api.observablehq.com/@d3/bar-chart.js?v=3`
+- `resolveFileAttachments`: A function that, given the name of a FileAttachment, returns the URL that the FileAttachment will be fetched from. Defaults to `name => name`.
+- `defineImportMarkdown`: A boolean, whether to define a markdown description cell for imports in the notebook. Defaults true.
+- `observeViewofValues`: A boolean, whether to pass in an _observer_ for the value of viewof cells.
+- `module`: A default Observable runtime [module](https://github.com/observablehq/runtime#modules) that will be used in operations such as `.cell` and `.module`, if no other module is passed in.
+- `observer`: A default Observable runtime [observer](https://github.com/observablehq/runtime#observer) that will be used in operations such as `.cell` and `.module`, if no other observer is passed in.
 
 Keep in mind, there is no sandboxing done, so it has the same security implications as `eval()`.
 
@@ -63,37 +63,31 @@ TODO
 
 new **Compiler**(_params_)
 
-`Compiler` is a class that encompasses all logic to compile Observable javascript code into vanilla Javascript code, as an ES module. _params_ is an optional object with the following allowed configuration.
+`Compiler` is a class that encompasses all logic to compile Observable javascript code into vanilla Javascript code, as an ES module. _params_ is an optional object with the following allowed configuration:
 
-`resolveImportPath(path, specifers)`: A function that returns a URL to where the notebook is defined. _path_ is the string provided in the import statement, and _specifiers_ is a array of string if the imported cell name specifiers in the statement (cells inside `import {...}`). _specifiers_ is useful when implementing tree-shaking. For example, `import {chart as CHART} from "@d3/bar-chart"` would supply `path="@d3/bar-chart"` and `specifiers=["chart"]`. Default imports from observablehq.com, eg `https://api.observablehq.com/@d3/bar-chart.js?v=3`
+- `resolveImportPath(path, specifers)`: A function that returns a URL to where the notebook is defined. _path_ is the string provided in the import statement, and _specifiers_ is a array of string if the imported cell name specifiers in the statement (cells inside `import {...}`). _specifiers_ is useful when implementing tree-shaking. For example, `import {chart as CHART} from "@d3/bar-chart"` would supply `path="@d3/bar-chart"` and `specifiers=["chart"]`. Default imports from observablehq.com, eg `https://api.observablehq.com/@d3/bar-chart.js?v=3`
+- `resolveFileAttachments`: A function that, given the name of a FileAttachment, returns the URL that the FileAttachment will be fetched from. Defaults to `name => name`.
+- `UNSAFE_allowJavascriptFileAttachments` A boolean. When true, the `resolveFileAttachments` function will resolve to raw JavaScript when calculating the value of a FileAttachment reference. This is useful if you need to use `new URL` or `import.meta.url` when determining where a FileAttachment url should resolve too. This is unsafe because the Compiler will not escape any quotes when including it in the compiled output, so do use with extreme caution when dealing with user input.
+  
+  ```javascript
 
-`resolveFileAttachments`: A function that, given the name of a FileAttachment, returns the URL that the FileAttachment will be fetched from. Defaults to `name => name`.
+  // This can be unsafe since FileAttachment names can include quotes.
+  // Instead, map file attachments names to something deterministic and escape-safe,
+  // like SHA hashes.
+  const resolveFileAttachments = name => `new URL("./files/${name}", import.meta.url)`
 
-`UNSAFE_allowJavascriptFileAttachments` A boolean. When true, the `resolveFileAttachments` function will resolve to raw JavaScript when calculating the value of a FileAttachment reference. This is useful if you need to use `new URL` or `import.meta.url` when determining where a FileAttachment url should resolve too. This is unsafe because the Compiler will not escape any quotes when including it in the compiled output, so do use with extreme caution when dealing with user input.
+  Compiled output when:
 
-```javascript
+  // UNSAFE_allowJavascriptFileAttachments == false
+  const fileAttachments = new Map([["a", "new URL(\"./files/a\", import.meta.url)"]]);
 
-// This can be unsafe since FileAttachment names can include quotes.
-// Instead, map file attachments names to something deterministic and escape-safe,
-// like SHA hashes.
-const resolveFileAttachments = name => `new URL("./files/${name}", import.meta.url)`
+  // UNSAFE_allowJavascriptFileAttachments == true
+  const fileAttachments = new Map([["a", new URL("./files/a", import.meta.url)]]);
 
-Compiled output when:
-
-// UNSAFE_allowJavascriptFileAttachments == false
-const fileAttachments = new Map([["a", "new URL(\"./files/a\", import.meta.url)"]]);
-
-// UNSAFE_allowJavascriptFileAttachments == true
-const fileAttachments = new Map([["a", new URL("./files/a", import.meta.url)]]);
-
-
-```
-
-`defineImportMarkdown` - A boolean, whether to define a markdown description cell for imports in the notebook. Defaults true.
-
-`observeViewofValues` - A boolean, whether or not to pass in the `observer` function for viewof value cells. Defaults true.
-
-`observeMutableValues` - A boolean, whether or not to pass in the `observer` function for mutable value cells. Defaults true.
+  ```
+- `defineImportMarkdown`: A boolean, whether to define a markdown description cell for imports in the notebook. Defaults true.
+- `observeViewofValues`: A boolean, whether or not to pass in the `observer` function for viewof value cells. Defaults true.
+- `observeMutableValues`: A boolean, whether or not to pass in the `observer` function for mutable value cells. Defaults true.
 
 compile.**module**(_source_)
 


### PR DESCRIPTION
Fixes missing line breaks for constructor options, adds consistent list formatting.

Note that GitHub's diffing seems to choke on the added code block indentation. Might wanna do a visual comparison instead.